### PR TITLE
wpe: Add faad gst plugins to rpi rdeps

### DIFF
--- a/recipes-wpe/wpe/wpe_0.1.bb
+++ b/recipes-wpe/wpe/wpe_0.1.bb
@@ -47,6 +47,7 @@ RDEPENDS_${PN} += " \
 
 RDEPENDS_${PN}_append_rpi = "\
     gstreamer1.0-omx \
+    gstreamer1.0-plugins-bad-faad \
     gstreamer1.0-plugins-bad-opengl \
 "
 


### PR DESCRIPTION
rpi needs it to play MPEG-4 AAC (audio/mpeg) streams

Signed-off-by: Khem Raj <raj.khem@gmail.com>