### PR TITLE
wpe: cleanup gstreamer plugins dependencies

### DIFF
--- a/recipes-wpe/wpe/wpe_0.1.bb
+++ b/recipes-wpe/wpe/wpe_0.1.bb
@@ -9,7 +9,6 @@ DEPENDS += " \
     bison-native gperf-native harfbuzz-native ninja-native ruby-native \
     cairo fontconfig freetype glib-2.0 gnutls harfbuzz icu jpeg pcre sqlite3 udev zlib \
     libinput libpng libsoup-2.4 libwebp libxml2 libxslt \
-    gstreamer1.0 gstreamer1.0-plugins-base \
     gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
     virtual/egl virtual/libgles2 \
 "
@@ -19,22 +18,13 @@ DEPENDS += " \
 # plugins-bad config option 'videoparsers' -> gstreamer1.0-plugins-bad-videoparsersbad
 
 RDEPENDS_${PN} += " \
+    gstreamer1.0-meta-base \
     gstreamer1.0-plugins-base-app \
-    gstreamer1.0-plugins-base-audioconvert \
-    gstreamer1.0-plugins-base-audioresample \
-    gstreamer1.0-plugins-base-playback \
-    gstreamer1.0-plugins-base-gio \
-    gstreamer1.0-plugins-base-videoconvert \
-    gstreamer1.0-plugins-base-videoscale \
-    gstreamer1.0-plugins-base-volume \
-    gstreamer1.0-plugins-base-typefindfunctions \
     gstreamer1.0-plugins-good-audiofx \
     gstreamer1.0-plugins-good-audioparsers \
-    gstreamer1.0-plugins-good-autodetect \
     gstreamer1.0-plugins-good-avi \
     gstreamer1.0-plugins-good-deinterlace \
     gstreamer1.0-plugins-good-interleave \
-    gstreamer1.0-plugins-good-souphttpsrc \
     gstreamer1.0-plugins-good-isomp4 \
     gstreamer1.0-plugins-good-wavparse \
     gstreamer1.0-plugins-bad-dashdemux \
@@ -68,12 +58,13 @@ inherit cmake pkgconfig perlnative pythonnative
 FULL_OPTIMIZATION_remove = "-g"
 
 WPE_BACKEND ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', 'rpi', d)}"
+
 PACKAGECONFIG ?= "${WPE_BACKEND} logs"
 
 PACKAGECONFIG[intelce] = "-DUSE_WPE_BACKEND_INTEL_CE=ON -DUSE_HOLE_PUNCH_GSTREAMER=ON,,intelce-display,gstreamer1.0-fsmd"
-PACKAGECONFIG[nexus] = "-DUSE_WPE_BACKEND_BCM_NEXUS=ON -DUSE_HOLE_PUNCH_GSTREAMER=ON,,broadcom-refsw gstreamer1.0-plugins-bad"
-PACKAGECONFIG[rpi] = "-DUSE_WPE_BACKEND_BCM_RPI=ON,,userland gstreamer1.0-plugins-bad gstreamer1.0-omx"
-PACKAGECONFIG[wayland] = "-DUSE_WPE_BACKEND_WAYLAND=ON -DUSE_WPE_BUFFER_MANAGEMENT_BCM_RPI=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,-DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,wayland libxkbcommon gstreamer1.0-plugins-bad"
+PACKAGECONFIG[nexus] = "-DUSE_WPE_BACKEND_BCM_NEXUS=ON -DUSE_HOLE_PUNCH_GSTREAMER=ON,,broadcom-refsw"
+PACKAGECONFIG[rpi] = "-DUSE_WPE_BACKEND_BCM_RPI=ON,,userland gstreamer1.0-omx"
+PACKAGECONFIG[wayland] = "-DUSE_WPE_BACKEND_WAYLAND=ON -DUSE_WPE_BUFFER_MANAGEMENT_BCM_RPI=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,-DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,wayland libxkbcommon"
 PACKAGECONFIG[logs] = "-DLOG_DISABLED=OFF,-DLOG_DISABLED=ON,"
 
 EXTRA_OECMAKE += " \


### PR DESCRIPTION
No functional changes, just remove some duplication.

Rely on the gstreamer1.0-meta-base package group to provide:

  gstreamer1.0-plugins-base-audioconvert
  gstreamer1.0-plugins-base-audioresample
  gstreamer1.0-plugins-base-gio
  gstreamer1.0-plugins-base-playback
  gstreamer1.0-plugins-base-typefindfunctions
  gstreamer1.0-plugins-base-videoconvert
  gstreamer1.0-plugins-base-videoscale
  gstreamer1.0-plugins-base-volume
  gstreamer1.0-plugins-good-autodetect
  gstreamer1.0-plugins-good-souphttpsrc

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>