### PR TITLE
qtbrowser: add recipe for version 2.0.5

### DIFF
--- a/recipes-qt/qtbrowser/files/conditional_WebSecurityEnabled.patch
+++ b/recipes-qt/qtbrowser/files/conditional_WebSecurityEnabled.patch
@@ -2,7 +2,26 @@ Index: git/qtbrowser.cpp
 ===================================================================
 --- git.orig/qtbrowser.cpp
 +++ git/qtbrowser.cpp
-@@ -59,7 +59,9 @@ void help(void) {
+@@ -26,6 +26,18 @@
+ #include <QtWidgets>
+ #endif
+ 
++/*
++   By default qtbrowser depends on qtwebkit extensions which are only available
++   in Metrological qtwebkit. Make use of these extensions conditional to support
++   building against upstream qtwebkit (which is still required since
++   Metrological qtwebkit doesn't currently support VirtualBox vbox32 builds).
++   Warning: Testing QT_VERSION is a temporary hack.
++*/
++#if (QT_VERSION == QT_VERSION_CHECK(5, 4, 1))
++/* Enable Metrological extensions */
++#define WEBSECURITY
++#endif
++
+ #include <QNetworkProxy>
+ #include <QNetworkReply>
+ #include <QNetworkAccessManager>
+@@ -59,7 +71,9 @@ void help(void) {
      "  --javascript=<on|off>          JavaScript execution (default: on)            \n"
      "  --private-browsing=<on|off>    Private browsing (default: off)               \n"
      "  --spatial-navigation=<on|off>  Spatial Navigation (default: off)             \n"
@@ -12,7 +31,7 @@ Index: git/qtbrowser.cpp
      "  --inspector=<port>             Inspector (default: disabled)                 \n"
      "  --max-cached-pages=<n>         Maximum pages in cache (default: 1)           \n"
      "  --pixmap-cache=<n>             Pixmap Cache size in MB (default: 20)         \n"
-@@ -113,7 +115,9 @@ int main(int argc, char *argv[]) {
+@@ -113,7 +127,9 @@ int main(int argc, char *argv[]) {
      settings->setAttribute(QWebSettings::WebAudioEnabled, true);
      settings->setAttribute(QWebSettings::PluginsEnabled, false);
      settings->setAttribute(QWebSettings::DeveloperExtrasEnabled, true);
@@ -22,7 +41,7 @@ Index: git/qtbrowser.cpp
      settings->setAttribute(QWebSettings::LocalContentCanAccessRemoteUrls, true);
      settings->setAttribute(QWebSettings::LocalStorageEnabled, true);
      settings->enablePersistentStorage(path);
-@@ -190,8 +194,10 @@ int main(int argc, char *argv[]) {
+@@ -190,8 +206,10 @@ int main(int argc, char *argv[]) {
              webSettingAttribute(QWebSettings::PrivateBrowsingEnabled, value);
          } else if (strncmp("--spatial-navigation", s, nlen) == 0) {
              webSettingAttribute(QWebSettings::SpatialNavigationEnabled, value);

--- a/recipes-qt/qtbrowser/qtbrowser_2.0.5.bb
+++ b/recipes-qt/qtbrowser/qtbrowser_2.0.5.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Metrological's Qt Browser for Qt 4 and 5"
+HOMEPAGE = "http://www.metrological.com/"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f73069ee5fe10af114e5300a37d32d44"
+
+DEPENDS = "qtbase qtwebkit"
+
+SRCREV = "b4996deede1207daa0bbe7bf3b590e435528fef5"
+PV = "2.0.5+gitr${SRCPV}"
+
+SRC_URI = "git://github.com/Metrological/qtbrowser.git;protocol=http"
+SRC_URI += "file://conditional_WebSecurityEnabled.patch"
+
+S = "${WORKDIR}/git"
+
+inherit qmake5
+
+OE_QMAKE_PATH_HEADERS = "${OE_QMAKE_PATH_QT_HEADERS}"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/qtbrowser ${D}${bindir}/
+}


### PR DESCRIPTION
qtbrowser 2.0.5 is the last version known to build relatively cleanly
against upstream qtwebkit 5.4.x (later versions are more dependent on
features found only in the Metrological fork of qtwebkit 5.4.1).
