### PR TITLE
images: Enable initramfs image

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -32,3 +32,7 @@ GPU_MEM_256 = "128"
 GPU_MEM_512 = "196"
 GPU_MEM_1024 = "396"
 
+# initramfs bits
+INITRAMFS_IMAGE_BUNDLE = "1"
+INITRAMFS_IMAGE = "rpi-hwup-image"
+

--- a/recipes-core/images/rpi-hwup-image.bbappend
+++ b/recipes-core/images/rpi-hwup-image.bbappend
@@ -15,3 +15,6 @@ IMAGE_INSTALL_append = "\
 "
 
 IMAGE_INSTALL_append_libc-glibc = " netflix "
+
+IMAGE_FSTYPES += "${INITRAMFS_FSTYPES}"
+


### PR DESCRIPTION
Use rpi-hwup-image as rootfs for bundled initramfs
finally, it will generate Image-initramfs-raspberrypi2.bin
in deploy area which is the single bootable image

Signed-off-by: Khem Raj <raj.khem@gmail.com>