### PR TITLE
initramfs-image: Fix build race for initramfs image and add new images

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,32 @@ How to use it:
     - meta-raspberrypi: `bitbake-layers add-layer ../meta-raspberrypi`
     - meta-metrological: `bitbake-layers add-layer ../meta-metrological`
     - meta-openembedded/meta-oe: `bitbake-layers add-layer ../meta-openembedded/meta-oe/`
-    - meta-openembedded/meta-multimedia: `bitbake-layers add-layer ../meta-openembedded/meta-multimedia/` 
+    - meta-openembedded/meta-multimedia: `bitbake-layers add-layer ../meta-openembedded/meta-multimedia/`
 3. Set MACHINE to "raspberrypi"/"raspberrypi2" in conf/local.conf. (see note on sdl):
     `echo 'MACHINE = "raspberrypi2"' >> conf/local.conf`
 4. By default this recipe builds WPE for RPI. If you want to build QT please set the following two environment variables:
 	`echo BROWSER=qt`
-	`export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE BROWSER"`	
-4. bitbake rpi-hwup-image
+	`export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE BROWSER"`
+4. bitbake wpe-image
 5. dd to a SD card the generated sdimg file (use xzcat if rpi-sdimg.xz is used)
 6. Boot your RPI.
 
+Enable initramfs image:
+
+  in conf/layer.conf uncomment
+
+  INITRAMFS_IMAGE_BUNDLE_rpi = "1"
+  INITRAMFS_IMAGE_rpi = "wpe-initramfs-image"
+  KERNEL_INITRAMFS = "-initramfs"
+  BOOT_SPACE = "163840"
+
+  Build monolithic image e.g. bitbake virtual/linux
+
+  To use monolithic image ( initramfs ) copy Image-initramfs-raspberrypi2.bin as Image into FAT primary partition
+  This image is virtually same as wpe-image
+
 **note**
-If you get the following error: 
+If you get the following error:
 `libsdl-native is set to be ASSUME_PROVIDED but sdl-config can't be found in PATH. Please either install it, or configure qemu not to require sdl.`
 
 Make sure the following is unset in conf/local.conf:

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,5 +33,8 @@ GPU_MEM_512 = "196"
 GPU_MEM_1024 = "396"
 
 # initramfs bits for rpi builds
-INITRAMFS_IMAGE_BUNDLE_rpi = "1"
-INITRAMFS_IMAGE_rpi = "rpi-hwup-image"
+#INITRAMFS_IMAGE_BUNDLE_rpi = "1"
+#INITRAMFS_IMAGE_rpi = "wpe-initramfs-image"
+#KERNEL_INITRAMFS = "-initramfs"
+# Enlarge boot partition to 160MiB
+#BOOT_SPACE = "163840"

--- a/recipes-core/images/core-image-weston.bbappend
+++ b/recipes-core/images/core-image-weston.bbappend
@@ -1,14 +1,4 @@
 # extend the wayland ref image
 
-IMAGE_FEATURES += " \
-    package-management \
-    ssh-server-openssh \
-"
-
-IMAGE_INSTALL_append = "\
-   packagegroup-ml-middleware \
-   packagegroup-ml-wpe \
-   ${@bb.utils.contains('BROWSER', 'qt', 'packagegroup-ml-qt5browser', '', d)} \
-"
-IMAGE_INSTALL_append_libc-glibc = " netflix "
+require wpe-image.inc
 

--- a/recipes-core/images/wpe-image.bb
+++ b/recipes-core/images/wpe-image.bb
@@ -1,0 +1,11 @@
+# Copyright (C) 2016 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "WPE initramfs rootfs image"
+LICENSE = "MIT"
+
+IMAGE_FEATURES += " \
+    package-management \
+"
+require recipes-core/images/rpi-basic-image.bb
+require wpe-image.inc

--- a/recipes-core/images/wpe-image.inc
+++ b/recipes-core/images/wpe-image.inc
@@ -1,13 +1,6 @@
-# extend the rpi-hwup-image
-
-IMAGE_FEATURES += " \
-    ssh-server-openssh \
-    splash \
-    package-management \
-"
-
 # selected based on browser type override
 # browser must be select through env variable: export BROWSER=qt and whitelisted with: export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE BROWSER"
+
 IMAGE_INSTALL_append = "\
    packagegroup-ml-middleware \
    packagegroup-ml-wpe \
@@ -16,4 +9,3 @@ IMAGE_INSTALL_append = "\
 
 IMAGE_INSTALL_append_libc-glibc = " netflix "
 
-IMAGE_FSTYPES_append_rpi = " ${INITRAMFS_FSTYPES}"

--- a/recipes-core/images/wpe-initramfs-image.bb
+++ b/recipes-core/images/wpe-initramfs-image.bb
@@ -1,0 +1,10 @@
+# Copyright (C) 2016 Khem Raj <raj.khem@gmail.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "WPE initramfs rootfs image"
+LICENSE = "MIT"
+
+require recipes-core/images/rpi-basic-image.bb
+require wpe-image.inc
+
+IMAGE_FSTYPES_rpi = " ${INITRAMFS_FSTYPES}"


### PR DESCRIPTION
Add wpe-image to replace existing latching on to rpi-hwup-image
this image inherits from rpi-basic-image instead which had features
we were enabling in bbappend

secondly, add wpe-initramfs-image for generating a monolithic image
bootable from FAT partition

Keep initramfs bits disabled by default

Adapt core-image-weston to use the new .inc file for including
WPE bits

Document the new imags in README

Signed-off-by: Khem Raj <raj.khem@gmail.com>