### PR TITLE
wpe-image: Use include instead of require for including another image

### DIFF
--- a/recipes-core/images/wpe-image.bb
+++ b/recipes-core/images/wpe-image.bb
@@ -7,5 +7,5 @@ LICENSE = "MIT"
 IMAGE_FEATURES += " \
     package-management \
 "
-require recipes-core/images/rpi-basic-image.bb
+include recipes-core/images/rpi-basic-image.bb
 require wpe-image.inc

--- a/recipes-core/images/wpe-initramfs-image.bb
+++ b/recipes-core/images/wpe-initramfs-image.bb
@@ -4,7 +4,7 @@
 DESCRIPTION = "WPE initramfs rootfs image"
 LICENSE = "MIT"
 
-require recipes-core/images/rpi-basic-image.bb
+include recipes-core/images/rpi-basic-image.bb
 require wpe-image.inc
 
 IMAGE_FSTYPES_rpi = " ${INITRAMFS_FSTYPES}"

--- a/recipes-wpe/wpe/wpe_0.1.bb
+++ b/recipes-wpe/wpe/wpe_0.1.bb
@@ -106,6 +106,7 @@ do_install() {
     # Hack: Remove RPATHs embedded in apps
     chrpath --delete ${D}${bindir}/WPENetworkProcess
     chrpath --delete ${D}${bindir}/WPEWebProcess
+    chrpath --delete ${D}${bindir}/WPEDatabaseProcess
 }
 
 LEAD_SONAME = "libWPEWebKit.so"


### PR DESCRIPTION
Makes it optional instead of mandatory to include the rpi image

Signed-off-by: Khem Raj <raj.khem@gmail.com>