### PR TITLE
webbridge: dont enable WEBBRIDGE_DEBUG by default

### DIFF
--- a/recipes-metrological/webbridge/webbridge_git.bb
+++ b/recipes-metrological/webbridge/webbridge_git.bb
@@ -21,7 +21,7 @@ PROVISIONING_libc-musl = ""
 PROVISIONING_mipsel = ""
 PROVISIONING_x86 = ""
 
-PACKAGECONFIG ??= "web-ui remotecontrol deviceinfo ${PROVISIONING} tracecontrol webproxy dailserver webkitbrowser debug"
+PACKAGECONFIG ??= "web-ui remotecontrol deviceinfo ${PROVISIONING} tracecontrol webproxy dailserver webkitbrowser"
 
 PACKAGECONFIG[debug]              = "-DWEBBRIDGE_DEBUG=ON,-DWEBBRIDGE_DEBUG=OFF,"
 PACKAGECONFIG[web-ui]             = "-DWEBBRIDGE_WEB_UI=ON,-DWEBBRIDGE_WEB_UI=OFF,"


### PR DESCRIPTION
Enabling WEBBRIDGE_DEBUG causes optimisation to be set to -O0, which
causes a lot of compiler warnings when building with security cflags
enabled:

  |  #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
  |     ^

