### PR TITLE
wpe: Set WPE_BACKEND correctly when vc4graphics is disabled

### DIFF
--- a/recipes-wpe/wpe/wpe_0.1.bb
+++ b/recipes-wpe/wpe/wpe_0.1.bb
@@ -31,14 +31,15 @@ inherit cmake pkgconfig perlnative pythonnative
 
 TOOLCHAIN = "gcc"
 
-WPE_BACKEND ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "wayland", "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros', 'rpi', d)}"}"
+WPE_BACKEND ?= "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'westeros', 'rpi', d)}"
+WPE_BACKEND_append = "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", " wayland","", d)}"
+WPE_BACKEND_remove = "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "westeros","", d)}"
 
 # The libprovision prebuilt libs currently support glibc ARM only.
 PROVISIONING ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "provisioning", d)}"
 PROVISIONING_libc-musl = ""
 PROVISIONING_mipsel = ""
 PROVISIONING_x86 = ""
-
 
 WL_BUFFER_MANAGEMENT ?= ""
 #WL_BUFFER_MANAGEMENT_rpi = "wl-rpi"


### PR DESCRIPTION
Current setting was not getting right packageconfig when
vc4graphics was unset, resulting in wrong backend being
compiled in.

Signed-off-by: Khem Raj <raj.khem@gmail.com>