### PR TITLE
wpe: add wpe-platform-plugin to RRECOMMENDS

### DIFF
--- a/recipes-wpe/wpe/wpe_0.1.bb
+++ b/recipes-wpe/wpe/wpe_0.1.bb
@@ -195,4 +195,5 @@ RDEPS_WEBAUDIO += "${RDEPS_EXTRA}"
 RRECOMMENDS_${PN} += " \
     ca-certificates \
     ttf-bitstream-vera \
+    ${PN}-platform-plugin \
 "


### PR DESCRIPTION
Usability is severely limited without the platform-plugin package,
so add it as a recommended runtime dependency.
