### PR TITLE
wpe: disable libprovision for hikey-32 machine

### DIFF
--- a/recipes-wpe/wpe/wpe_0.1.bb
+++ b/recipes-wpe/wpe/wpe_0.1.bb
@@ -37,6 +37,7 @@ PROVISIONING ?= "${@bb.utils.contains("MACHINE_FEATURES", "vc4graphics", "", "pr
 PROVISIONING_libc-musl = ""
 PROVISIONING_mipsel = ""
 PROVISIONING_x86 = ""
+PROVISIONING_hikey-32 = ""
 
 WL_BUFFER_MANAGEMENT ?= ""
 #WL_BUFFER_MANAGEMENT_rpi = "wl-rpi"


### PR DESCRIPTION
Remove libprovision dependency for hikey as depends on restricted license cppsdk