### PR TITLE
wpe: add missing dependency on chrpath-replacement-native

### DIFF
--- a/recipes-wpe/wpe/wpe_0.1.bb
+++ b/recipes-wpe/wpe/wpe_0.1.bb
@@ -6,7 +6,7 @@ LICENSE = "BSD & LGPLv2+"
 LIC_FILES_CHKSUM = "file://Source/WebCore/LICENSE-LGPL-2.1;md5=a778a33ef338abbaf8b8a7c36b6eec80 "
 
 DEPENDS += " \
-    bison-native gperf-native harfbuzz-native ninja-native ruby-native \
+    bison-native gperf-native harfbuzz-native ninja-native ruby-native chrpath-replacement-native \
     cairo fontconfig freetype glib-2.0 gnutls harfbuzz icu jpeg pcre sqlite3 zlib \
     libinput libpng libsoup-2.4 libwebp libxml2 libxslt \
     virtual/egl virtual/libgles2 \


### PR DESCRIPTION
Adding chrpath-native to EXTRANATIVEPATH (see recent commit) sets up
the PATH to use the OE version of chrpath-native, however a dependency
on chrpath-replacement-native is also required to ensure that the OE
version of chrpath-native is deterministically available.
